### PR TITLE
ライブラリサンプルが動かせるようパスを修正

### DIFF
--- a/DirectXLibrary/DirectXLibrary.vcxproj
+++ b/DirectXLibrary/DirectXLibrary.vcxproj
@@ -39,13 +39,13 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -94,6 +94,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)DirectXLibrary\GameLib;$(SolutionDir)DirectXLibrary\GameLib\DX\DX3D\CustomVertexEditor\Data;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PreprocessorDefinitions>DIRECTINPUT_VERSION=0x0800;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>d3dx9d.lib;d3d9.lib;dinput8.lib;dxguid.lib;winmm.lib;libfbxsdk-mt.lib;SoundLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -122,10 +123,13 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>false</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)DirectXLibrary\GameLib;$(SolutionDir)DirectXLibrary\GameLib\DX\DX3D\CustomVertexEditor\Data;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>DIRECTINPUT_VERSION=0x0800;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>d3dx9.lib;d3d9.lib;dinput8.lib;dxguid.lib;winmm.lib;libfbxsdk-mt.lib;SoundLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DirectXLibrary/GameLib/DX/DX3D/FbxStorage/FbxRelated/FbxModel/FbxModel.cpp
+++ b/DirectXLibrary/GameLib/DX/DX3D/FbxStorage/FbxRelated/FbxModel/FbxModel.cpp
@@ -13,8 +13,6 @@
 #define _CRTDBG_MAP_ALLOC
 #define new ::new(_NORMAL_BLOCK, __FILE__, __LINE__)
 
-#pragma comment(lib,"libfbxsdk-md.lib")
-
 FbxModel::FbxModel(const LPDIRECT3DDEVICE9 m_pDX_GRAPHIC_DEVICE)
 {
 	m_pDevice = m_pDX_GRAPHIC_DEVICE;

--- a/DirectXLibrary/GameLib/DX/DX3D/FbxStorage/FbxRelated/FbxRelated.cpp
+++ b/DirectXLibrary/GameLib/DX/DX3D/FbxStorage/FbxRelated/FbxRelated.cpp
@@ -7,8 +7,6 @@
 #include <fbxsdk.h>
 #include "FbxRelated.h"
 
-#pragma comment(lib,"libfbxsdk-md.lib")
-
 FbxRelated::FbxRelated(const LPDIRECT3DDEVICE9 dXGraphicDevice) :m_pDX_GRAPHIC_DEVICE(dXGraphicDevice)
 {
 	m_pFbxManager = NULL;

--- a/LibSample/LibSample.vcxproj
+++ b/LibSample/LibSample.vcxproj
@@ -49,7 +49,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -71,7 +71,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LibraryPath>$(FBXSDK_DIR)lib\vs2015\x64\debug\;$(DXSDK_DIR)Lib\x64\;$(SolutionDir)DirectXLibrary\SoundLib\Debug_x64\Lib\;$(LibraryPath)</LibraryPath>
-    <IncludePath>$(FBXSDK_DIR)include\;$(DXSDK_DIR)Include\;$(SolutionDir)DirectXLibrary\SoundLib\Debug_x64\Include\;$(ExecutablePath)</IncludePath>
+    <IncludePath>$(FBXSDK_DIR)include\;$(DXSDK_DIR)Include\;$(SolutionDir)DirectXLibrary\SoundLib\Debug_x64\Include\;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(SolutionDir)DirectXLibrary\SoundLib\Release_x64\Include;$(DXSDK_DIR)Include;$(FBXSDK_DIR)include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)DirectXLibrary\SoundLib\Release_x64\Lib;$(DXSDK_DIR)Lib\x64;$(FBXSDK_DIR)lib\vs2015\x64\release;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -79,12 +83,12 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>false</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)DirectXLibrary\GameLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)DirectXLibrary\GameLib;$(SolutionDir)DirectXLibrary\GameLib\DX\DX3D\CustomVertexEditor\Data;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>d3dx9d.lib;d3d9.lib;dinput8.lib;dxguid.lib;winmm.lib;libfbxsdk-mt.lib;SoundLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3dx9d.lib;d3d9.lib;dinput8.lib;dxguid.lib;winmm.lib;libfbxsdk-mt.lib;SoundLib.lib;DirectXLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -116,11 +120,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
+      <ConformanceMode>false</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)DirectXLibrary\GameLib;$(SolutionDir)DirectXLibrary\GameLib\DX\DX3D\CustomVertexEditor\Data;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>d3dx9.lib;d3d9.lib;dinput8.lib;dxguid.lib;winmm.lib;libfbxsdk-mt.lib;SoundLib.lib;DirectXLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
- インクルードディレクトリを書く場所が間違えているため修正
- Debug版にしかディレクトリ等を設定していないためRelease版にも追加
- FBX関係のソースにmd版のFBXSDKを読み込んでいるので削除

Closes #8