### PR TITLE
LibのインターフェイスをEffect関係クラスに引き渡す方法の修正

### DIFF
--- a/DirectXLibrary/Class/Singleton/Singleton.h
+++ b/DirectXLibrary/Class/Singleton/Singleton.h
@@ -16,13 +16,6 @@ public:
 
 		return *ptr;
 	}
-
-	inline static T* GetInstancePtr()
-	{
-		static std::unique_ptr<T> ptr(new T());
-
-		return ptr;
-	}
 };
 
 #endif // !SINGLETON_H

--- a/DirectXLibrary/Class/Singleton/Singleton.h
+++ b/DirectXLibrary/Class/Singleton/Singleton.h
@@ -16,6 +16,13 @@ public:
 
 		return *ptr;
 	}
+
+	inline static T* GetInstancePtr()
+	{
+		static std::unique_ptr<T> ptr(new T());
+
+		return ptr;
+	}
 };
 
 #endif // !SINGLETON_H

--- a/DirectXLibrary/GameLib/EffectManager/Effect/Effect.cpp
+++ b/DirectXLibrary/GameLib/EffectManager/Effect/Effect.cpp
@@ -17,6 +17,8 @@
 #include "Particle/Particle.h"
 #include "Algorithm\Algorithm.h"
 
+IGameLibRenderer* Effect::m_pIGameLibRenderer = nullptr;
+
 void Effect::Render()
 {
 	m_pIGameLibRenderer->AddtionBlendMode();

--- a/DirectXLibrary/GameLib/EffectManager/Effect/Effect.h
+++ b/DirectXLibrary/GameLib/EffectManager/Effect/Effect.h
@@ -51,11 +51,11 @@ public:
 	/// GameLibの描画関係を集めたもの
 	/// </summary>
 	/// <param name="pIGameLibRenderer">GameLibの描画関連のインターフェイス</param>
-	inline void SetGameLibRenderer(IGameLibRenderer* pIGameLibRenderer)
+	static inline void SetGameLibRenderer(IGameLibRenderer* pIGameLibRenderer)
 	{
 		m_pIGameLibRenderer = pIGameLibRenderer;
 
-		m_particles[0]->SetGameLibRenderer(pIGameLibRenderer);
+		Particle::SetGameLibRenderer(pIGameLibRenderer);
 	}
 
 	virtual inline void Update() = 0;
@@ -87,7 +87,7 @@ protected:
 
 	virtual void Init(Particle* pParticle) = 0;
 
-	IGameLibRenderer* m_pIGameLibRenderer = nullptr;
+	static IGameLibRenderer* m_pIGameLibRenderer;
 
 	std::vector<Particle*> m_particles;
 

--- a/DirectXLibrary/GameLib/EffectManager/Effect/Particle/Behavior/Behavior.h
+++ b/DirectXLibrary/GameLib/EffectManager/Effect/Particle/Behavior/Behavior.h
@@ -42,7 +42,7 @@ public:
 	/// GameLibの描画関係を集めたもの
 	/// </summary>
 	/// <param name="pIGameLibRenderer">GameLibの描画関連のインターフェイス</param>
-	inline void SetGameLibRenderer(IGameLibRenderer* pIGameLibRenderer)
+	static inline void SetGameLibRenderer(IGameLibRenderer* pIGameLibRenderer)
 	{
 		m_pIGameLibRenderer = pIGameLibRenderer;
 	}

--- a/DirectXLibrary/GameLib/EffectManager/Effect/Particle/Particle.h
+++ b/DirectXLibrary/GameLib/EffectManager/Effect/Particle/Particle.h
@@ -36,11 +36,11 @@ public:
 	/// GameLibの描画関係を集めたもの
 	/// </summary>
 	/// <param name="pIGameLibRenderer">GameLibの描画関連のインターフェイス</param>
-	inline void SetGameLibRenderer(IGameLibRenderer* pIGameLibRenderer)
+	static inline void SetGameLibRenderer(IGameLibRenderer* pIGameLibRenderer)
 	{
 		m_pIGameLibRenderer = pIGameLibRenderer;
 
-		m_behavior.SetGameLibRenderer(pIGameLibRenderer);
+		Behavior::SetGameLibRenderer(pIGameLibRenderer);
 	}
 
 	/// <summary>

--- a/DirectXLibrary/GameLib/EffectManager/EffectManager.cpp
+++ b/DirectXLibrary/GameLib/EffectManager/EffectManager.cpp
@@ -15,10 +15,8 @@
 
 #include "Effect\Effect.h"
 
-void EffectManager::AddEffect(IGameLibRenderer* m_pIGameLibRenderer, Effect* pEffect)
+void EffectManager::AddEffect(Effect* pEffect)
 {
-	pEffect->SetGameLibRenderer(m_pIGameLibRenderer);
-
 	m_pEffects.push_back(pEffect);
 }
 

--- a/DirectXLibrary/GameLib/EffectManager/EffectManager.h
+++ b/DirectXLibrary/GameLib/EffectManager/EffectManager.h
@@ -23,7 +23,10 @@
 class EffectManager
 {
 public:
-	EffectManager() {};
+	explicit EffectManager(IGameLibRenderer* m_pIGameLibRenderer)
+	{
+		Effect::SetGameLibRenderer(m_pIGameLibRenderer);
+	}
 
 	~EffectManager() 
 	{
@@ -34,7 +37,7 @@ public:
 	/// エフェクトの追加
 	/// </summary>
 	/// <param name="pEffect">追加したいエフェクトのポインタ</param>
-	void AddEffect(IGameLibRenderer* m_pIGameLibRenderer, Effect* pEffect);
+	void AddEffect(Effect* pEffect);
 
 	/// <summary>
 	/// エフェクトの更新

--- a/DirectXLibrary/GameLib/GameLib.h
+++ b/DirectXLibrary/GameLib/GameLib.h
@@ -65,7 +65,6 @@ public:
 		if (!m_pSound)			m_pSound		 = new Sound();
 		if (!m_pBoard3D)		m_pBoard3D		 = new Board3D();
 		if (!m_pJoyconManager)	m_pJoyconManager = new JoyconManager();
-		if (!m_pEffectManager)  m_pEffectManager = new EffectManager(GetInstancePtr());
 		if (!m_pXinputManager)  m_pXinputManager = new XinputManager();
 	}
 
@@ -977,7 +976,7 @@ public:
 	/// <param name="pEffect">追加したいエフェクトのポインタ</param>
 	inline void AddEffect(Effect* pEffect)
 	{
-		m_pEffectManager->AddEffect(static_cast<IGameLibRenderer*>(this), pEffect);
+		m_pEffectManager->AddEffect(pEffect);
 	}
 
 	/// <summary>
@@ -1255,7 +1254,10 @@ public:
 	}
 
 private:
-	GameLib() {};
+	GameLib() 
+	{
+		if (!m_pEffectManager)  m_pEffectManager = new EffectManager(static_cast<IGameLibRenderer*>(this));
+	}
 
 	static Wnd* m_pWnd;
 

--- a/DirectXLibrary/GameLib/GameLib.h
+++ b/DirectXLibrary/GameLib/GameLib.h
@@ -65,9 +65,8 @@ public:
 		if (!m_pSound)			m_pSound		 = new Sound();
 		if (!m_pBoard3D)		m_pBoard3D		 = new Board3D();
 		if (!m_pJoyconManager)	m_pJoyconManager = new JoyconManager();
-		if (!m_pEffectManager)  m_pEffectManager = new EffectManager();
+		if (!m_pEffectManager)  m_pEffectManager = new EffectManager(GetInstancePtr());
 		if (!m_pXinputManager)  m_pXinputManager = new XinputManager();
-		GetInstance();
 	}
 
 	/**


### PR DESCRIPTION
インターフェイスのインスタンスを引き渡す順番を変更しそれのNULLアクセスをしないようにする

Closes #14 